### PR TITLE
Expose nodemailer configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Simple-Auth aims to be highly configurable and this configuration comes in the f
 Below you will find a list of all the available variables, their description and types.
 
 ## DATABASE_TYPE *
-      
+
 - **Required**: true
 - **Type**: string
 - **Values**: postgres, mysql
@@ -85,108 +85,136 @@ Below you will find a list of all the available variables, their description and
 - **Description**: The host name of your database, this could be the name of the service inside a docker network or a url
 
 ## DATABASE_NAME *
-      
+
 - **Required**: true
 - **Type**: string
 - **Description**: The name of the database to connect to. It is up to you to unsure that the database is created before initialising the service
 
 ## DATABASE_PORT *
-      
+
 - **Required**: true
 - **Type**: number
 - **Description**: The port in which the database service is listening
 
 ## DATABASE_USERNAME *
-      
+
 - **Required**: true
 - **Type**: string
 - **Description**: The user of the database to use in the connection
 
 ## DATABASE_PASSWORD *
-      
+
 - **Required**: true
 - **Type**: string
 - **Description**: The password of the user to use in the connection
-      
+
 ## TOKEN_ENCRYPTION_KEY *
-      
+
 - **Required**: true
 - **Type**: string
 - **Description**: The secret key to encrypt the tokens with. We are currently using [node-jsonwebtoken](https://github.com/auth0/node-jsonwebtoken#usage) you can find more information there.
 
 ## PASSWORD_RESET_URL *
+
 - **Required**: true
 - **Type**: string
 - **Description**: A URL to your app's page for a password reset. This page will be used when a user requests requests a password reset (usually forgotten password). When a user forgets their password, an email will be sent to the user's email with the link to this page and an additional query property which you will then need to pass to the API for the reset. Ex: if you pass `http://mywebsite.co/password-reset` the request will reach your page like so: `http://mywebsite.co/password-reset?passwordResetId=<some-uuid>`, you will then need to pass that UUID to the correct endpoint to trigger the password reset for the user. The idea here is that you will have control of the workflow and the design of the page for password reset without gimmiks from our service.
 
 ## PASSWORD_PEPPER
-      
+
 - **Required**: false
 - **Type**: string
 - **Description**: A string to be used as [pepper](https://en.wikipedia.org/wiki/Pepper_(cryptography)) in protecting user passwords. **If you set this you can not change it a later time as it would make it impossible to verify previously hashed passwords**
 - **Default Value**: ""
       
 ## PORT
-      
+
 - **Required**: false
 - **Type**: number
 - **Description**: The port in which the HTTP server will run
 - **Default Value**: 5000
 
 ## ACCESS_TOKEN_EXPIRE_TIME
-      
+
 - **Required**: false
 - **Type**: number
 - **Description**: The number of seconds a token should last. This should be a short time, 10 to 60 minutes usually
 - **Default Value**: 600 (10 minutes)
 
 ## REFRESH_TOKEN_EXPIRE_TIME
-      
+
 - **Required**: false
 - **Type**: number
-- **Description**: The number of seconds the refresh token should last. This token is long lived, usually between serveral days or months. When this token expires your user will have to login again
+- **Description**: The number of seconds the refresh token should last. This token is long lived, usually between several days or months. When this token expires your user will have to login again
 - **Default Value**: 2629743 (~30 days)
 
 ## MODE
-      
+
 - **Required**: false
 - **Type**: string
 - **Description**: The mode the service should run in. Possible values include ["dev", "prod"]. dev mode will show more debug information
 - **Default Value**: prod
 
+## SMTP_DEBUG
+
+- **Required**: false
+- **Type**: boolean
+- **Description**: Enables SMTP communication logs
+
 ## SMTP_HOST
-      
+
 - **Required**: false
 - **Type**: string
 - **Description**: The server host of the SMTP email client to use. If none is provided the auth service will not send confirmation emails
 
 ## SMTP_PORT
-      
+
 - **Required**: false (true if using [SMTP_HOST](#SMTP_HOST))
 - **Type**: number
 - **Description**: The server port where the SMTP server is running
 
 ## SMTP_SECURE
-      
+
 - **Required**: false
 - **Type**: boolean
-- **Description**: Wether to use TLS in the connection to the server
+- **Description**: Wether to use TLS in the connection to the server. If false (the default) then TLS is used if server supports the STARTTLS: [smtp-tls-options](https://nodemailer.com/smtp/#tls-options)
 - **Default Value**: false
 
+## SMTP_REQUIRE_TLS
+
+- **Required**: false
+- **Type**: boolean
+- **Description**: When set to true and secure is false it tries to use STARTTLS even if the server does not advertise support for it. If the connection can not be encrypted then message is not sent: [smtp-tls-options](https://nodemailer.com/smtp/#tls-options)
+- **Default Value**: false
+
+## SMTP_IGNORE_TLS
+
+- **Required**: false
+- **Type**: boolean
+- **Description**: When set to true and secure is false then TLS is not used even if the server supports STARTTLS extension: [smtp-tls-options](https://nodemailer.com/smtp/#tls-options)
+- **Default Value**: false
+
+## SMTP_TLS_CIPHERS
+
+- **Required**: false
+- **Type**: string
+- **Description**: TLS Cipher
+- **Default Value**: SSLv3
+
 ## SMTP_USER
-      
+
 - **Required**: false (true if using [SMTP_HOST](#SMTP_HOST))
 - **Type**: string
 - **Description**: The user to connect to the SMTP server
 
 ## SMTP_PASSWORD
-      
+
 - **Required**: false (true if using [SMTP_HOST](#SMTP_HOST))
 - **Type**: string
 - **Description**: The password of the user to connect to the SMTP server
 
 ## SMTP_MAIL_FROM
-      
+
 - **Required**: false (true if using [SMTP_HOST](#SMTP_HOST))
 - **Type**: string
 - **Description**: The email address that will show up in "From" when sending emails

--- a/package-lock.json
+++ b/package-lock.json
@@ -6480,9 +6480,9 @@
       }
     },
     "swagger-ui-dist": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.1.2.tgz",
-      "integrity": "sha512-Pj960coj9L0nAQPE1vgBzHulKGPNw1ifn/1GTIv/mlV9V3PoRM0uTcE0uhTiizx6aHg+vnFFmbA2J1gjFekOaQ=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.1.3.tgz",
+      "integrity": "sha512-WvfPSfAAMlE/sKS6YkW47nX/hA7StmhYnAHc6wWCXNL0oclwLj6UXv0hQCkLnDgvebi0MEV40SJJpVjKUgH1IQ=="
     },
     "swagger-ui-express": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "class-transformer": "^0.4.0",
     "class-validator": "^0.13.2",
     "jsonwebtoken": "^8.5.1",
-    "nodemailer": "^6.5.0",
+    "nodemailer": "^6.7.2",
     "pg": "^8.7.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/src/services/Environment/Environment.ts
+++ b/src/services/Environment/Environment.ts
@@ -78,10 +78,9 @@ export class Environment {
         return field;
     }
 
-    private boolean(field): boolean {
-        const parsedField = Boolean(field);
-        if(typeof parsedField === "boolean") {
-            return parsedField;
+    private boolean(field = ""): boolean {
+        if(field.toLocaleLowerCase() === "true") {
+            return true;
         }
 
         return false;

--- a/src/services/Environment/Environment.ts
+++ b/src/services/Environment/Environment.ts
@@ -14,9 +14,13 @@ export class Environment {
     public ACCESS_TOKEN_EXPIRE_TIME: number;
     public REFRESH_TOKEN_EXPIRE_TIME: number;
     public MODE: string;
+    public SMTP_DEBUG: boolean;
     public SMTP_HOST: string;
     public SMTP_PORT: number;
     public SMTP_SECURE: boolean;
+    public SMTP_REQUIRE_TLS: boolean;
+    public SMTP_IGNORE_TLS: boolean;
+    public SMTP_TLS_CIPHERS: string;
     public SMTP_USER: string;
     public SMTP_PASSWORD: string;
     public SMTP_MAIL_FROM: string;
@@ -38,9 +42,13 @@ export class Environment {
         this.ACCESS_TOKEN_EXPIRE_TIME = this.defaultIfNotEmpty(this.number(process.env.ACCESS_TOKEN_EXPIRE_TIME), 600);
         this.REFRESH_TOKEN_EXPIRE_TIME = this.defaultIfNotEmpty(this.number(process.env.REFRESH_TOKEN_EXPIRE_TIME), 2629743);
         this.MODE = this.defaultIfNotEmpty(process.env.MODE, "prod");
+        this.SMTP_DEBUG = this.boolean(process.env.SMTP_DEBUG);
         this.SMTP_HOST = this.defaultIfNotEmpty(process.env.SMTP_HOST, "");
         this.SMTP_PORT = this.defaultIfNotEmpty(this.number(process.env.SMTP_PORT), undefined);
         this.SMTP_SECURE = this.boolean(process.env.SMTP_SECURE);
+        this.SMTP_REQUIRE_TLS = this.boolean(process.env.SMTP_REQUIRE_TLS);
+        this.SMTP_IGNORE_TLS = this.boolean(process.env.SMTP_IGNORE_TLS);
+        this.SMTP_TLS_CIPHERS = this.defaultIfNotEmpty(process.env.SMTP_TLS_CIPHERS, "SSLv3");
         this.SMTP_USER = this.defaultIfNotEmpty(process.env.SMTP_USER, "");
         this.SMTP_PASSWORD = this.defaultIfNotEmpty(process.env.SMTP_PASSWORD, "");
         this.SMTP_MAIL_FROM = this.defaultIfNotEmpty(process.env.SMTP_MAIL_FROM, "");

--- a/src/services/Mail/Nodemailer.ts
+++ b/src/services/Mail/Nodemailer.ts
@@ -22,10 +22,17 @@ export class Nodemailer implements IMail {
             host: this.envService.SMTP_HOST,
             port: this.envService.SMTP_PORT,
             secure: this.envService.SMTP_SECURE,
+            requireTLS: this.envService.SMTP_REQUIRE_TLS,
+            ignoreTLS: this.envService.SMTP_IGNORE_TLS,
+            tls: {
+                ciphers:this.envService.SMTP_TLS_CIPHERS,
+            },
             auth: {
                 user: this.envService.SMTP_USER,
                 pass: this.envService.SMTP_PASSWORD
             },
+            debug: this.envService.SMTP_DEBUG,
+            logger: this.envService.SMTP_DEBUG,
         });
     }
 
@@ -43,7 +50,7 @@ export class Nodemailer implements IMail {
             await this.transporter.verify();
             return true;
         } catch (error) {
-            this.logger.log(`Email service is offiline`);
+            this.logger.log('Email service is offline');
             return false;
         }
     }


### PR DESCRIPTION
Closes: https://github.com/GJordao/simple-auth/issues/37
Closes: https://github.com/GJordao/simple-auth/issues/38

When trying to register a new user `/auth/register` started to notice that the user would return with the "accountActive" set to true, and "Email service is offiline" message. While trying to debug and switch between SMTP configurations I have noticed that some TLS options are not exposed. https://github.com/GJordao/simple-auth/issues/38

Also, added a new ENV VAR `STMP_DEBUG` to allow debuging smtp related issues.

BTW: The reported issue was related with the bug reported on https://github.com/GJordao/simple-auth/issues/37 , I was setting SMTP_secure=false but it was always enabling that option.

### PR changes requires for the local .env file to use a new setup to work with the smtp.ethereal.email service:

```bash
SMTP_SECURE=false
SMTP_REQUIRE_TLS=true
SMTP_IGNORE_TLS=false
 ```

Question: should I set this to be the default behaviour if no env var is set? (SMTP_REQUIRE_TLS default value set to true ???)